### PR TITLE
[BUGFIX] Skip further processing if no site found

### DIFF
--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -202,6 +202,10 @@ class Queue
 
             /* @var SiteRepository $siteRepository */
             $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
+            if ($siteRepository->getSiteByRootPageId($rootPageId) === null) {
+                continue;
+            }
+            
             $solrConfiguration = $siteRepository->getSiteByRootPageId($rootPageId)->getSolrConfiguration();
             $indexingConfiguration = $this->recordService->getIndexingConfigurationName($itemType, $itemUid, $solrConfiguration);
             if ($indexingConfiguration === null) {


### PR DESCRIPTION
# What this pr does

Skip processing if site is not found.

# How to test

Given, you have a global storage page (with a site configured, but solr disabled) to store records.

Fixes: #3407
